### PR TITLE
WIP: Updates to be performant with many HTML files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -986,16 +986,13 @@
       }
     },
     "fs-extra": {
-      "version": "0.26.7",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
-      "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
-      "dev": true,
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
+      "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
       "requires": {
         "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0",
-        "klaw": "1.3.1",
-        "path-is-absolute": "1.0.1",
-        "rimraf": "2.6.1"
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.1"
       }
     },
     "fs.realpath": {
@@ -1075,8 +1072,7 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -1426,10 +1422,9 @@
       "dev": true
     },
     "jsonfile": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
         "graceful-fs": "4.1.11"
       }
@@ -3506,6 +3501,19 @@
             "mime-types": "2.1.16"
           }
         },
+        "fs-extra": {
+          "version": "0.26.7",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
+          "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "2.4.0",
+            "klaw": "1.3.1",
+            "path-is-absolute": "1.0.1",
+            "rimraf": "2.6.1"
+          }
+        },
         "har-validator": {
           "version": "2.0.6",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
@@ -3516,6 +3524,15 @@
             "commander": "2.11.0",
             "is-my-json-valid": "2.16.0",
             "pinkie-promise": "2.0.1"
+          }
+        },
+        "jsonfile": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
           }
         },
         "node-uuid": {
@@ -4083,6 +4100,11 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "universalify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "bluebird": "^3.4.0",
     "commander": "^2.9.0",
+    "fs-extra": "^4.0.2",
     "glob": "^7.0.3",
     "is-absolute-url": "^2.0.0",
     "is-html": "^1.0.0",

--- a/src/uncss.js
+++ b/src/uncss.js
@@ -145,9 +145,9 @@ function processWithTextApi(files, options, stylesheets) {
         /* Try and construct a helpful error message */
         throw utility.parseErrorMessage(err, cssStr);
     }
-    return uncss(files, pcss, options).spread(function (css, rep) {
+    return uncss(files, pcss, options).spread(function (usedCss, rep) {
         var newCssStr = '';
-        postcss.stringify(css, function(result) {
+        postcss.stringify(usedCss, function(result) {
             newCssStr += result;
         });
 
@@ -220,7 +220,11 @@ function process(opts, callback) {
         .then(function(stylesheets) {
           return processWithTextApi(files, opts, stylesheets);
         })
-        .asCallback(callback, { spread: !opts.usePostCssInternal });
+        .then(function(result) {
+            var usedCss = result[0];
+            var report = result[1];
+            callback(null, usedCss, report);
+        });
 }
 
 var postcssPlugin = postcss.plugin('uncss', function (opts) {


### PR DESCRIPTION
WIP: Updates to be performant with many HTML files

 - Create jsdom instances as we go instead of batching
 - The second commit is just rough nicety bits to get the stats I was after
   - Caching of used selector counts so we don't need to process the file over and over
   - Save out a map of selector usage


Without these changes, running `uncss` with many(1566) HTML files will result in the following error:

```
<--- Last few GCs --->

  239117 ms: Mark-sweep 1323.8 (1434.4) -> 1322.8 (1434.4) MB, 992.2 / 0 ms [allocation failure] [GC in old space requested].
  240073 ms: Mark-sweep 1322.8 (1434.4) -> 1322.5 (1434.4) MB, 955.9 / 0 ms [allocation failure] [GC in old space requested].
  241047 ms: Mark-sweep 1322.5 (1434.4) -> 1322.5 (1434.4) MB, 973.6 / 0 ms [last resort gc].
  242000 ms: Mark-sweep 1322.5 (1434.4) -> 1322.5 (1434.4) MB, 952.7 / 0 ms [last resort gc].


<--- JS stacktrace --->

==== JS stack trace =========================================

Security context: 0000003B3D8C9E51 <JS Object>
    1: filter(aka filter) [uncss\node_modules\jsdom\lib\jsdom\living\node.js:95] [pc=0000036AE42573CA] (this=0000003B3D804189 <undefined>,node=000003E2FFBDB901 <an EventTargetImpl with map 000002294BDB22C1>)
    2: treeToArray [uncss\node_modules\symbol-tree\lib\SymbolTree.js:~338] [pc=0000036AE35A29D1] (this=000002F4DD4ABFD9 <a Symb...

FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory
```