### PR TITLE
Add output option for cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Options:
   -n, --noBanner                        Disable banner
   -a, --userAgent <string>              Use a custom user agent string
   -I, --inject <file>                   Path to javascript file to be executed before uncss runs
+  -o, --output <file>                   Path to write resulting CSS to
 ```
 
 **Note that you can pass both local file paths (which are processed by [glob](https://github.com/isaacs/node-glob)) and URLs to the program.**

--- a/bin/uncss
+++ b/bin/uncss
@@ -7,7 +7,8 @@
 
     const uncss = require('../src/uncss.js'),
         data = require('../package.json'),
-        program = require('commander');
+        program = require('commander'),
+        fs = require('fs');
 
     let buffer = '',
         options;
@@ -31,6 +32,7 @@
         .option('-n, --noBanner', 'Disable banner')
         .option('-a, --userAgent <string>', 'Use a custom useragent string')
         .option('-I, --inject <file>', 'Path to javascript file to be executed before uncss runs')
+        .option('-o, --output <file>', 'Path to write resulting CSS to')
         .parse(process.argv);
 
     options = {
@@ -76,7 +78,16 @@
             if (err) {
                 throw err;
             }
-            console.log(css);
+            if (program.output) {
+                fs.writeFile(program.output, css, 'utf8', (err) => {
+                    if (err) {
+                        throw err;
+                    }
+                    console.log(`${program.output} has been saved!`);
+                });
+            } else {
+                console.log(css);
+            }
         });
     } else {
         /* No files were specified, read HTML from stdin */


### PR DESCRIPTION
Using stdout sometimes results in extra information (console.log statements) being included in the output. This adds an option for outputting the resulting CSS to a file rather than just stdout.

I was focused on getting my particular use-case satisfied. Let me know if I can do better/more.