### PR TITLE
 Redirect stdout (console.log) to stderr

### DIFF
--- a/src/jsdom.js
+++ b/src/jsdom.js
@@ -2,6 +2,7 @@
 
 const jsdom = require('jsdom/lib/old-api.js'),
     path = require('path'),
+    { Console } = require('console'),
     _ = require('lodash');
 
 /**
@@ -16,7 +17,7 @@ function fromSource(src, options) {
             FetchExternalResources: ['script'],
             ProcessExternalResources: ['script']
         },
-        virtualConsole: jsdom.createVirtualConsole().sendTo(console),
+        virtualConsole: jsdom.createVirtualConsole().sendTo(new Console(process.stderr)),
         userAgent: options.userAgent
     };
 

--- a/tests/jsdom.js
+++ b/tests/jsdom.js
@@ -156,11 +156,8 @@ describe('jsdom', () => {
             expect(err).to.equal(null);
             expect(output).to.include('.evaluated');
 
-            let methods = ['log', 'info'];
-            methods.forEach((method) => {
-                expect(stdout).to.not.include(method);
-                expect(stderr).to.include(method);
-            });
+            expect(stdout).to.not.include('log');
+            expect(stderr).to.include('log');
 
             done();
         });

--- a/tests/jsdom.js
+++ b/tests/jsdom.js
@@ -156,7 +156,7 @@ describe('jsdom', () => {
             expect(err).to.equal(null);
             expect(output).to.include('.evaluated');
 
-            let methods = ['debug', 'log', 'info'];
+            let methods = ['log', 'info'];
             methods.forEach((method) => {
                 expect(stdout).to.not.include(method);
                 expect(stderr).to.include(method);

--- a/tests/jsdom.js
+++ b/tests/jsdom.js
@@ -133,4 +133,36 @@ describe('jsdom', () => {
             done();
         });
     });
+
+    // The use-case here is when using the cli to redirect output to a file:
+    //   uncss tests/jsdom/console.html > output.css
+    it('Should redirect console statements to stderr', (done) => {
+        // Overwrite stdout and stderr so we can monitor the output
+        const oldout = process.stdout.write,
+            olderr = process.stderr.write;
+        let stdout = '',
+            stderr = '';
+        process.stdout.write = function (content) {
+            stdout += content;
+        };
+        process.stderr.write = function (content) {
+            stderr += content;
+        };
+
+        uncss(['tests/jsdom/console.html'], (err, output) => {
+            process.stdout.write = oldout;
+            process.stderr.write = olderr;
+
+            expect(err).to.equal(null);
+            expect(output).to.include('.evaluated');
+
+            let methods = ['debug', 'log', 'info'];
+            methods.forEach((method) => {
+                expect(stdout).to.not.include(method);
+                expect(stderr).to.include(method);
+            });
+
+            done();
+        });
+    });
 });

--- a/tests/jsdom/console.html
+++ b/tests/jsdom/console.html
@@ -13,7 +13,7 @@
             document.body.appendChild(div);
         </script>
         <script>
-            var methods = ['debug', 'log', 'info'];
+            var methods = ['log', 'info'];
             methods.forEach(function (method) {
                 console[method](method);
             });

--- a/tests/jsdom/console.html
+++ b/tests/jsdom/console.html
@@ -13,10 +13,7 @@
             document.body.appendChild(div);
         </script>
         <script>
-            var methods = ['log', 'info'];
-            methods.forEach(function (method) {
-                console[method](method);
-            });
+            console.log('log');
         </script>
     </body>
 </html>

--- a/tests/jsdom/console.html
+++ b/tests/jsdom/console.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>jsdom basic test</title>
+        <link rel="stylesheet" href="jsdom.css">
+    </head>
+    <body>
+        <script>
+            /* Append an element */
+            var div = document.createElement('div');
+            div.className = 'evaluated';
+            document.body.appendChild(div);
+        </script>
+        <script>
+            var methods = ['debug', 'log', 'info'];
+            methods.forEach(function (method) {
+                console[method](method);
+            });
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
When using the cli to redirect output to a file, `console.log` statements within scripts will end up in the resulting css. As brought up in uncss/uncss#385, this uses the virtual console to redirect all console output to `stderr`.