### PR TITLE
Avoid of options mutation

### DIFF
--- a/src/uncss.js
+++ b/src/uncss.js
@@ -192,7 +192,7 @@ function init(files, options, callback) {
     }
 
     /* Assign default values to options, unless specified */
-    options = _.defaults(options, {
+    options = _.defaults({
         csspath: '',
         ignore: [],
         media: [],
@@ -205,7 +205,7 @@ function init(files, options, callback) {
         raw: null,
         userAgent: 'uncss',
         inject: null
-    });
+    }, options);
 
     process(options).then(([css, report]) => callback(null, css, report), callback);
 }


### PR DESCRIPTION
The error occurs when multiple sets of files are processed as lodash's defaults method mutates the object. So on the second iteration of uncss `options` object has all the data from previous iteration including `html` that fails check in process method