### PR TITLE
Add option to exclude html files

### DIFF
--- a/src/uncss.js
+++ b/src/uncss.js
@@ -16,13 +16,17 @@ const glob = require('glob'),
  * @return {Array|Promise}
  */
 function getHTML(files, options) {
+    const globOpts = {
+        ignore: options.ignoreHtml
+    };
+
     if (_.isString(files)) {
         files = [files];
     }
 
     files = _.flatten(files.map((file) => {
         if (!isURL(file) && !isHTML(file)) {
-            return glob.sync(file);
+            return glob.sync(file, globOpts);
         }
         return file;
     }));
@@ -193,6 +197,7 @@ function init(files, options, callback) {
 
     /* Assign default values to options, unless specified */
     options = _.defaults(options, {
+        ignoreHtml: [],
         csspath: '',
         ignore: [],
         media: [],
@@ -239,6 +244,7 @@ const postcssPlugin = postcss.plugin('uncss', (opts) => {
         // Ignore stylesheets in the HTML files; only use those from the stream
         ignoreSheets: [/\s*/],
         html: [],
+        ignoreHtml: [],
         ignore: []
     });
 

--- a/tests/glob.js
+++ b/tests/glob.js
@@ -18,4 +18,18 @@ describe('Using globbing patterns', () => {
             done();
         });
     });
+
+    it('should find only first index pages in the directory and return the used CSS for it', (done) => {
+        uncss(['tests/glob/**/*.html'], { ignoreHtml: ['tests/glob/**/two.html'] }, (err, output) => {
+            expect(err).to.equal(null);
+            expect(output).to.not.equal(undefined);
+            expect(output).to.contain('h1');
+            expect(output).not.to.contain('h2');
+            expect(output).not.to.contain('h3');
+            expect(output).not.to.contain('h4');
+            expect(output).not.to.contain('h5');
+            expect(output).not.to.contain('h6');
+            done();
+        });
+    });
 });

--- a/tests/postcss.js
+++ b/tests/postcss.js
@@ -41,7 +41,7 @@ describe('PostCSS Plugin', () => {
             });
     });
 
-    it('Respects the ignores param', (done) => {
+    it('Respects the ignore param', (done) => {
         let opts = {
             ignore: ['h4']
         };
@@ -54,6 +54,27 @@ describe('PostCSS Plugin', () => {
                 expect(result.css).not.to.contain('h2');
                 expect(result.css).not.to.contain('h3');
                 expect(result.css).to.contain('h4');
+                expect(result.css).not.to.contain('h5');
+                expect(result.css).not.to.contain('h6');
+                done();
+            }, (error) => {
+                done(error);
+            });
+    });
+
+    it('Respects the ignoreHtml param', (done) => {
+        let opts = {
+            ignoreHtml: ['./tests/glob/two.html']
+        };
+        opts.html = ['./tests/glob/*.html'];
+        postcss([uncss.postcssPlugin(opts)]).process(prevRun)
+            .then((result) => {
+                expect(result.warnings().length).to.equal(0);
+                expect(result.css).to.not.equal(undefined);
+                expect(result.css).to.contain('h1');
+                expect(result.css).not.to.contain('h2');
+                expect(result.css).not.to.contain('h3');
+                expect(result.css).not.to.contain('h4');
                 expect(result.css).not.to.contain('h5');
                 expect(result.css).not.to.contain('h6');
                 done();


### PR DESCRIPTION
By introducing the option `ignoreHtml` it's now possible to exclude HTML files from processing.

For example within a pattern library like [Pattern Lab](https://patternlab.io/) I need to exclude a lot of files. This is a glimpse of a common file tree:
- public/patterns/00-atoms-00-global-00-brand-colors/00-atoms-00-global-00-brand-colors.html
- public/patterns/00-atoms-00-global-00-brand-colors/00-atoms-00-global-00-brand-colors.markup-only.html
- public/patterns/00-atoms-00-global-01-base-colors/00-atoms-00-global-01-base-colors.html
- public/patterns/00-atoms-00-global-01-base-colors/00-atoms-00-global-01-base-colors.markup-only.html
- public/patterns/00-atoms-00-global/index.html
- ...

With the follow setup...
```js
postCssUncss({
	html: [
		'public/patterns/**/*.html',
	],
	ignoreHtml: [
		'public/patterns/**/*.markup-only.html',
		'public/patterns/**/index.html',
	],
})
```

... only these are processed:
- public/patterns/00-atoms-00-global-00-brand-colors/00-atoms-00-global-00-brand-colors.html
- public/patterns/00-atoms-00-global-01-base-colors/00-atoms-00-global-01-base-colors.html

With around 100 patterns this is a major performance improvement and prevent error output for files where the html skeleton (markup-only) is missing. 

Please consider this for a new release. =)