### PR TITLE
Allow user to disable strictSSL checking in jsdom request

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ var files   = ['my', 'array', 'of', 'HTML', 'files', 'or', 'http://urls.com'],
         uncssrc      : '.uncssrc',
         userAgent    : 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X)',
         inject       : function(window){ window.document.querySelector('html').classList.add('no-csscalc', 'csscalc'); }
+        strictSSL    : true
     };
 
 uncss(files, options, function (error, output) {
@@ -211,6 +212,8 @@ See [PostCSS docs](https://github.com/postcss/postcss) for examples for your env
       /* this will NOT be ignored */
   }
   ```
+
+- **strictSSL** (Boolean): Disable SSL verification when retrieving html source
 
 ##### Example Configuration
 

--- a/src/jsdom.js
+++ b/src/jsdom.js
@@ -45,6 +45,10 @@ function fromSource(src, options) {
         };
     }
 
+    if (options.strictSSL !== undefined) {
+      config.strictSSL = options.strictSSL
+    }
+
     return new Promise((resolve, reject) => {
         jsdom.env(src, config, (err, res) => {
             if (err) {

--- a/src/jsdom.js
+++ b/src/jsdom.js
@@ -46,7 +46,7 @@ function fromSource(src, options) {
     }
 
     if (options.strictSSL !== undefined) {
-      config.strictSSL = options.strictSSL
+        config.strictSSL = options.strictSSL;
     }
 
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
When running uncss with an insecure certificate (e.g. local dev environment), the user should be allowed to disable strict ssl checking to avoid ssl errors. See [359](https://github.com/uncss/uncss/issues/359)