### PR TITLE
Fix parsing error when css starts with BOM

### DIFF
--- a/src/utility.js
+++ b/src/utility.js
@@ -100,6 +100,19 @@ function parsePaths(source, stylesheets, options) {
 }
 
 /**
+ * Given an UTF8 string, return a version of this string without the first byte if it corresponds
+ *   to the Byte Order Mark
+ * @param {String}  utf8String the string to strip
+ * @return {String}
+ */
+function stripBom(utf8String) {
+    if (utf8String.charCodeAt(0) === 0xFEFF) {
+        return utf8String.substr(1);
+    }
+    return utf8String;
+}
+
+/**
  * Given an array of filenames, return an array of the files' contents,
  *   only if the filename matches a regex
  * @param  {Array}   files  An array of the filenames to read
@@ -125,7 +138,7 @@ function readStylesheets(files, outputBanner) {
                     if (err) {
                         return reject(err);
                     }
-                    return resolve(contents);
+                    return resolve(stripBom(contents));
                 });
             });
         }

--- a/tests/bom.js
+++ b/tests/bom.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const expect = require('chai').expect,
+    uncss = require('../src/uncss');
+
+describe('Compile the CSS of an HTML page passed by path', () => {
+    it('Should not crash when there the css file starts with BOM + @', (done) => {
+        uncss(['tests/input/testbom.html'], (err, output) => {
+            expect(err).to.equal(null);
+            expect(output).to.include('body');
+            done();
+        });
+    });
+});

--- a/tests/input/testbom.html
+++ b/tests/input/testbom.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>testbom</title>
+        <link rel="stylesheet" href="with_bom.css">
+    </head>
+
+    <body>
+
+        <h1>Loading a css stylesheet starting with the BOM character</h1>
+
+    </body>
+</html>

--- a/tests/input/with_bom.css
+++ b/tests/input/with_bom.css
@@ -1,0 +1,9 @@
+﻿@namespace testbom "http://bom.for_utf8.com";
+
+body {
+  font-family:Helvetica Neue, Helvetica, Arial;
+}
+
+h1 {
+  font-weight: normal;
+}


### PR DESCRIPTION
When the css file starts with the Byte Order Mark and the first line is
@namespace, the parser fails:

```
|| <css input>:2:1: Unknown word
|| 	1:        /*** uncss> filename: tests/input/with_bom.css ***/
|| 	2:     -> @namespace testbom "http://bom.for_utf8.com";
```

The solution taken to deal with it is to strip the BOM at the beginning of the file.

It doesn't seem to be problematic with @media or with @import