### PR TITLE
remove empty :not selectors

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -46,10 +46,25 @@ const dePseudify = (() => {
         // Actual regex is of the format: /^(:hover|:focus|...)$/i
         pseudosRegex = new RegExp(`^(${ignoredPseudos.join('|')})$`, 'i');
 
+    const removeEmptyNodes = node => {
+        if (!node.nodes) {
+            return;
+        }
+        node.each(removeEmptyNodes);
+        if (node.length === 0) {
+            node.remove();
+        }
+    };
+
     const transform = selectors => {
         selectors.walkPseudos(selector => {
             if (pseudosRegex.test(selector.value)) {
                 selector.remove();
+            }
+        });
+        selectors.walkPseudos(selector => {
+            if (selector.value === ':not') {
+                removeEmptyNodes(selector);
             }
         });
     };

--- a/tests/depseudify.js
+++ b/tests/depseudify.js
@@ -29,6 +29,8 @@ describe('dePseudify() function', () => {
         'p:hover:not(.fancy)': 'p:not(.fancy)',
         'p:not(.fancy)': 'p:not(.fancy)',
         'p:not(.fancy):hover': 'p:not(.fancy)',
+        'input:not(:checked)': 'input',
+        'input:not(:checked,.fancy)': 'input:not(.fancy)',
     };
 
     Object.keys(expected).forEach((input) => {


### PR DESCRIPTION
Fixes #353 
Fixes #370 (partially)

> PR #448 is a simpler alternative which doesn't try to fix dangling commas

After _depseudify_, a `:not` pseudo-class may become an empty `:not()`. Calling `document.querySelector` with an empty `:not` raises an exception and the entire selector is kept, because `jsdom#findAll` optimistically ignores all errors.

This PR adds a second pass to `dePseudify`: after removal of `ignoredPseudos`, a new walk is performed in search of empty `:not` selectors.

At same time, this PR fixes when the selector `:not()` takes a list of selectors and one of them has been removed by `dePseudify`. Currently, a dangling comma is left when an element of the list is removed (although the current version of `jsdom` doesn't raise an error, this syntax is invalid).

### Current behavior:

* `dePseudify`[`.control:not(:checked)`] => `.control:not()`
  * In this scenario, `document.querySelector('.control:not()')` raises an exception and the selector is kept.
* `dePseudify`[`.control:not(:checked, .checked)`] => `.control:not(,.checked)`
  * Note the dangling comma

### Pull proposal:

* `dePseudify`[`.control:not(:checked)`] => `.control`
  * No empty `:not()`
* `dePseudify`[`.control:not(:checked, .checked)`] => `.control:not(.checked)`
  * No dangling comma
