### PR TITLE
replaces console.err (not a function) by console.log

### DIFF
--- a/bin/uncss
+++ b/bin/uncss
@@ -83,7 +83,7 @@
                     if (err) {
                         throw err;
                     }
-                    console.err(`${program.output} has been saved!`);
+                    console.error(`${program.output} has been saved!`);
                 });
             } else {
                 console.log(css);

--- a/bin/uncss
+++ b/bin/uncss
@@ -83,7 +83,7 @@
                     if (err) {
                         throw err;
                     }
-                    console.error(`${program.output} has been saved!`);
+                    console.log(`${program.output} has been saved!`);
                 });
             } else {
                 console.log(css);


### PR DESCRIPTION
Fixes a typo

TypeError: console.err is not a function:
https://github.com/uncss/uncss/blob/d0adf4bb89ef4f82006f8dd5b40d22a94269e50a/bin/uncss#L86
