### PR TITLE
remove empty :not selectors (simpler alternative to PR #446)

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -52,6 +52,11 @@ const dePseudify = (() => {
                 selector.remove();
             }
         });
+        selectors.walkPseudos((selector) => {
+            if (selector.toString() === ':not()') {
+                selector.remove()
+            }
+        });
     };
 
     const processor = postcssSelectorParser(transform);

--- a/tests/depseudify.js
+++ b/tests/depseudify.js
@@ -29,6 +29,8 @@ describe('dePseudify() function', () => {
         'p:hover:not(.fancy)': 'p:not(.fancy)',
         'p:not(.fancy)': 'p:not(.fancy)',
         'p:not(.fancy):hover': 'p:not(.fancy)',
+        'input:not(:checked)': 'input',
+        'input:not(:disabled):not(.disabled)': 'input:not(.disabled)'
     };
 
     Object.keys(expected).forEach((input) => {


### PR DESCRIPTION
Fixes #353 

> A simpler alternative to PR #446. This commit only remove empty :not() selectors and doesn't try to fix dangling commas

After _depseudify_, a `:not` pseudo-class may become an empty `:not()`. Calling `document.querySelector` with a empty `:not` raises an exception and all selector is kept, because `jsdom#findAll` ignores all errors optimistically:

https://github.com/uncss/uncss/blob/d0adf4bb89ef4f82006f8dd5b40d22a94269e50a/src/jsdom.js#L158-L165

This PR adds a second step to `dePseudify`: after removal of `ignoredPseudos`, a new walk is performed searching for empty `:not` selectors.

### Actual behavior:

* `dePseudify`[`.control:not(:checked)`] => `.control:not()`
  * In this scenario, `document.querySelector('.control:not()')` raises an exception and the selector is kept.

### Pull proposal:

* `dePseudify`[`.control:not(:checked)`] => `.control`
  * No empty `:not()`
